### PR TITLE
update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
         "url": "https://github.com/GitbookIO/plugin-puml/issues"
     },
     "dependencies": {
-        "plantuml-encoder": "1.2.3"
+        "plantuml-encoder": "1.2.4"
     },
     "devDependencies": {
-        "gitbook-tester": "1.3.0",
-        "mocha": "2.3.4"
+        "gitbook-tester": "1.4.3",
+        "mocha": "3.2.0"
     },
     "scripts": {
         "test": "node_modules/.bin/mocha --reporter spec --timeout 15000"


### PR DESCRIPTION
Folllowing issue was fixed.

[unescape is not support UTF-8?](https://github.com/markushedvall/plantuml-encoder/issues/4)

So, could you update dependencies version?

And node v7 requires devDependencies update 